### PR TITLE
Move styled-components to the peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,9 @@
   "dependencies": {
     "prop-types": "^15.5.8",
     "react": "^15.5.4",
-    "react-dom": "^15.5.4",
+    "react-dom": "^15.5.4"
+  },
+  "peerDependencies": {
     "styled-components": "^2.1.0"
   }
 }


### PR DESCRIPTION
According to https://github.com/styled-components/styled-components/issues/992, styled-components modules shouldn't be duplicated.
Components will lose their styles if someone will be using `react-css-loaders` and manually depends on `styled-components`.